### PR TITLE
[Fix] Undefined path fix

### DIFF
--- a/packages/ella/src/general/index.ts
+++ b/packages/ella/src/general/index.ts
@@ -332,7 +332,7 @@ export function getData(obj: any, path: string, def: null | unknown = null): any
     const newPathArray = String(sanitzePath(path)).split('.');
 
     for (const path of newPathArray) {
-      obj = obj[path] as any;
+      obj = obj?.[path] as any;
     }
 
     return typeof obj === 'undefined' ? def : obj;


### PR DESCRIPTION
When we call getData function like this 

`if utmData = { a: 'data', utm_source: undefined};`
`getData(utmDataObj, 'utmData.utm_source', null);`

This will throw type error

<img width="727" alt="Screenshot 2022-03-15 at 10 23 26 AM" src="https://github.com/Groww-OSS/webster/assets/114666956/61013819-13c5-4e31-9c1d-c7fa57c90d99">
