### PR TITLE
bumped react js version in peerDeps for react-charts in webster

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/react-charts",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "React charts library tailored as per Groww needs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## What does this PR do?
Bumped version of react in peer dependencies of react-charts.
Earlier it was 16.0.0, now we have pushed it to 17.0.0 using ||.
This is to avoid warnings while performing pnpm i of mismatching peerDeps.

## What packages have been affected by this PR?
react-charts

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?



## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [x] Changes need to be immediately published on npm. 
