### PR TITLE
fix(ella): removed typedoc warnings coming in build

### DIFF
--- a/packages/ella/src/number/NumberFormatter/index.ts
+++ b/packages/ella/src/number/NumberFormatter/index.ts
@@ -165,7 +165,7 @@ const defaultNumberConfig = {
  * ```
  *
  */
-export function NumberFormatter(num: string | number, numberConfig: numberConfigType = {}) {
+export function NumberFormatter(num: string | number, numberConfig: NumberConfig = {}) {
 
   const initNumberConfig = {
     ...defaultNumberConfig, // will add all the default config and then overwrite with existing numberConfig which is passed.
@@ -379,7 +379,7 @@ function returnSignValueStr(sign : string, value : number | string, spaceBetween
 }
 
 
-type numberConfigType = {
+export type NumberConfig = {
   addCommas?: boolean;
   millionCommas?: boolean;
   fallback?: any;

--- a/packages/ella/src/number/index.ts
+++ b/packages/ella/src/number/index.ts
@@ -5,6 +5,7 @@
 import { isEmpty } from '../general';
 
 export { NumberFormatter } from './NumberFormatter';
+export type { NumberConfig } from './NumberFormatter';
 
 /**
  * This method can be used to add commas as per Indian system to any valid number of type string or number.
@@ -107,7 +108,7 @@ export function isValidMobileNumber(mobNumber: number | string) {
  * ```
  */
 export function convertPaisaToRupee(value: number | string) {
-   return parseFloat(value as string) / 100;
+  return parseFloat(value as string) / 100;
 }
 
 /**

--- a/packages/ella/src/utils/index.ts
+++ b/packages/ella/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './JsonLd';
+export * from './types';

--- a/packages/ella/typedoc.json
+++ b/packages/ella/typedoc.json
@@ -5,7 +5,8 @@
     "./src/general/index.ts",
     "./src/jsx/index.tsx",
     "./src/number/index.ts",
-    "./src/string/index.ts"
+    "./src/string/index.ts",
+    "./src/utils/index.ts"
   ],
   "out": "docs"
 }


### PR DESCRIPTION
## What does this PR do?
Removes all type-doc warnings encountered while building package `ella` by improving re-exporting.
This PR resolves #240 

## What packages have been affected by this PR?
ella

## Types of changes
Before:
![image](https://github.com/Groww-OSS/webster/assets/114666956/a214870e-7d57-4708-a80b-17b319b215c6)
After: 
<img width="1191" alt="image" src="https://github.com/Groww-OSS/webster/assets/114666956/8d5bae54-8f1a-4a63-8109-f952266dd13d">


What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [x] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
No


## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
