### PR TITLE
fixed ui toolkit dep size increased unconditionally

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -111,7 +111,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript": "^1.0.1",
     "typescript": "4.5.5",
-    "@groww-tech/icon-store": "workspace:*"
+    "@groww-tech/icon-store": "1.3.0"
   },
   "dependencies": {
     "flat-carousel": "0.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
       '@babel/preset-react': ^7.13.13
       '@babel/preset-typescript': ^7.13.0
       '@groww-tech/base-css': workspace:*
-      '@groww-tech/icon-store': workspace:*
+      '@groww-tech/icon-store': 1.3.0
       '@rollup/plugin-commonjs': ^19.0.0
       '@rollup/plugin-node-resolve': ^11.2.1
       '@stitches/react': ^1.2.7
@@ -328,7 +328,7 @@ importers:
       '@babel/preset-react': 7.18.6_@babel+core@7.21.3
       '@babel/preset-typescript': 7.21.0_@babel+core@7.21.3
       '@groww-tech/base-css': link:../base-css
-      '@groww-tech/icon-store': link:../icon-store
+      '@groww-tech/icon-store': 1.3.0_react@16.14.0
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.79.1
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
       '@stitches/react': 1.2.8_react@16.14.0
@@ -2137,6 +2137,14 @@ packages:
       lodash.isequal: 4.5.0
       react-helmet: 6.1.0
     dev: false
+
+  /@groww-tech/icon-store/1.3.0_react@16.14.0:
+    resolution: {integrity: sha512-DN8DGO8oXDVomV7BaUmF6Kp2Fv1bJID3ABjWz2Pq+JV06piYGM/0nKWu+2yD7C+VtDguHK9dDHs+uGdbsH+weA==}
+    peerDependencies:
+      react: ^16.12.0
+    dependencies:
+      react: 16.14.0
+    dev: true
 
   /@humanwhocodes/config-array/0.5.0:
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
@@ -8734,7 +8742,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
## What does this PR do?
ui-toolkit had @groww-tech/icon-store in dependencies.
This was causing it to bundle entire icon-store along with the main package.

This increased the bundle size from 66kb -> ~234kb

This Pr fixes the above issue by making the icon-store package a peerDep and
adding icon-store in devDependencies.



## What packages have been affected by this PR?
ui-toolkit

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [x] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
0.3.1 -> 0.3.2 (ui-toolkit)


## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [x] Changes need to be immediately published on npm. 
