### PR TITLE
feat: added prop to hide bottom axis line in react charts

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/react-charts",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React charts library tailored as per Groww needs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-charts/src/BarGraph/index.tsx
+++ b/packages/react-charts/src/BarGraph/index.tsx
@@ -20,6 +20,7 @@ const BarGraph = (props: BarGraphProps) => {
     getBarTopTextUI,
     getTooltipUI,
     showAxis,
+    hideAxisBottomLine,
     showTooltip,
     bottomAxisHeight
   } = props;
@@ -91,6 +92,7 @@ const BarGraph = (props: BarGraphProps) => {
         stroke={axisColor}
         orientation='bottom'
         hideTicks
+        hideAxisLine={hideAxisBottomLine}
         tickLabelProps={
           () => ({
             fill: axisLabelColor,
@@ -210,6 +212,7 @@ type DefaultProps = {
   getBarTopTextUI: (textX : number, textY: number, barData: BarData) => SVGElement | null;
   getTooltipUI: (index: number, x: number, y: number, barHeight: number) => ReactNode;
   showAxis: boolean;
+  hideAxisBottomLine?: boolean;
   showTooltip?: boolean;
   axisLabelFontSize?: number;
   axisLabelColor?: string;
@@ -231,6 +234,7 @@ BarGraph.defaultProps = {
   getBarTopTextUI: () => null,
   getTooltipUI: () => null,
   showAxis: false,
+  hideAxisBottomLine: false,
   showTooltip: false,
   axisLabelFontSize: 11,
   axisLabelColor: 'var(--gray900)',


### PR DESCRIPTION
## What does this PR do?
Adds a prop to hide bottom axis line 

Before:
<img width="792" alt="image" src="https://github.com/user-attachments/assets/274eef7e-a86e-4ce1-bd43-52157991a442">

After:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/c217e3b4-2c5e-45ad-a230-193fa628bd0b">


## What packages have been affected by this PR?
`react-charts`

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?



## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [x] Changes need to be immediately published on npm. 
