### PR TITLE
font ligature disabled

### DIFF
--- a/packages/mint-css/base/app.css
+++ b/packages/mint-css/base/app.css
@@ -59,6 +59,7 @@ body {
   font-family: GrowwSans,NotoSans, system-ui;
   min-width: 320px;
   -webkit-font-smoothing: antialiased;
+  font-variant-ligatures: none;
 }
 
 a {

--- a/packages/mint-css/package.json
+++ b/packages/mint-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/mint-css",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A CSS library that provides classes, tokens, variables, fonts and other essential stylings governed under MINT design system, used by Groww",
   "main": "./dist/bundle.css",
   "files": [


### PR DESCRIPTION
## What does this PR do?
ligature property disabled because of issue in ios18.
![IMG_8843](https://github.com/user-attachments/assets/93f488ce-2ce7-4432-9d0d-fb389b11b6e9)

## What packages have been affected by this PR?
mint-css

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
mint-css


## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
