### PR TITLE
token updated for secondary button disabled state

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.8.0",
+  "version": "0.8.0-beta.1",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "@groww-tech/icon-store": "1.4.6",
-    "@groww-tech/mint-css": "0.1.9",
+    "@groww-tech/mint-css": "0.2.9",
     "flat-carousel": "0.0.1",
     "lodash.debounce": "4.0.8",
     "object-assign": "4.1.1",

--- a/packages/ui-toolkit/src/components/atoms/Button/Button.tsx
+++ b/packages/ui-toolkit/src/components/atoms/Button/Button.tsx
@@ -54,7 +54,7 @@ const Button = (props: Props) => {
   const secondaryButtonClasses = cn('mint-btn-secondary', {
     'mint-btn-secondary-default': !isAccent,
     'mint-btn-secondary-accent backgroundAccentSubtle': (isAccent && !isDisabled) || (isAccent && isDisabled && isLoading),
-    'mint-btn-secondary-default-border': !isAccent
+    'mint-btn-secondary-default-border': !isAccent && !isDisabled
   });
 
   const tertiaryButtonClasses = cn('mint-btn-tertiary', {
@@ -93,7 +93,7 @@ const Button = (props: Props) => {
       'mint-btn-full-width': isFullWidth,
       'mint-btn-loader': isLoading,
       'mint-btn-compact': variant === VARIANTS.TERTIARY && isCompact,
-      'mint-btn-disabled': isDisabled && !isLoading
+      'mint-btn-disabled backgroundDisabled': isDisabled && !isLoading
     });
 
 

--- a/packages/ui-toolkit/src/components/atoms/Button/styles/button.css
+++ b/packages/ui-toolkit/src/components/atoms/Button/styles/button.css
@@ -55,7 +55,6 @@
 .mint-btn-disabled{
   cursor: default;
   pointer-events: none;
-  background-color: var(--border-primary);
 }
 
 .mint-btn-disabled.mint-btn-tertiary-disabled{


### PR DESCRIPTION
## What does this PR do?
`backgroundColor` replaced with updated Token for secondary button in disabled state.
Ref - https://growwhq.slack.com/archives/C071X3R4F70/p1741766836922469

## What packages have been affected by this PR?
ui-toolkit

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
ui-toolkit


## Checklist before merging

_Put an `x` in the boxes that apply_

- [ ] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
