### PR TITLE
feat: add gradient variant to Button component and update default props

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/react-charts",
-  "version": "0.1.9-beta.0",
+  "version": "0.2.0",
   "description": "React charts library tailored as per Groww needs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.8.0-beta.2",
+  "version": "0.8.1",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-toolkit/src/components/atoms/Button/Button.constants.ts
+++ b/packages/ui-toolkit/src/components/atoms/Button/Button.constants.ts
@@ -3,7 +3,8 @@ export const VARIANTS = {
   SECONDARY: 'Secondary',
   TERTIARY: 'Tertiary',
   POSITIVE: 'Positive',
-  NEGATIVE: 'Negative'
+  NEGATIVE: 'Negative',
+  GRADIENT: 'Gradient'
 };
 
 

--- a/packages/ui-toolkit/src/components/atoms/Button/Button.tsx
+++ b/packages/ui-toolkit/src/components/atoms/Button/Button.tsx
@@ -42,8 +42,8 @@ const Button = (props: Props) => {
     type,
     rel,
     target,
-    onClick,
-    gradientClass
+    gradientClass,
+    onClick
   } = props;
 
   const primaryButtonClasses = cn('mint-btn-primary',

--- a/packages/ui-toolkit/src/components/atoms/Button/Button.tsx
+++ b/packages/ui-toolkit/src/components/atoms/Button/Button.tsx
@@ -16,7 +16,7 @@ import { isEmpty } from '../../../utils/helper';
 import './styles/index.css';
 
 
-const isValidHyperLink = (href: string | undefined) : boolean => {
+const isValidHyperLink = (href: string | undefined): boolean => {
   return (
     !isEmpty(href) && (!(href === '#' || href === 'javascript:void(0)'))
   );
@@ -42,7 +42,8 @@ const Button = (props: Props) => {
     type,
     rel,
     target,
-    onClick
+    onClick,
+    gradientClass
   } = props;
 
   const primaryButtonClasses = cn('mint-btn-primary',
@@ -114,6 +115,14 @@ const Button = (props: Props) => {
     borderDisabled: variant === VARIANTS.TERTIARY && isDisabled && !isLoading && !isAccent
   });
 
+  const gradientButtonClasses = cn(
+    {
+      contentOnColour: !isLoading && !isDisabled,
+      [gradientClass]: !isDisabled || (isLoading && isDisabled),
+      borderPrimary: isDisabled && !isLoading && !isAccent
+    }
+  );
+
 
   const getButtonClassesBasedOnVariant = () => {
     switch (variant) {
@@ -131,6 +140,9 @@ const Button = (props: Props) => {
 
       case VARIANTS.NEGATIVE:
         return cn(baseClasses, negativeButtonClasses);
+
+      case VARIANTS.GRADIENT:
+        return cn(baseClasses, gradientButtonClasses);
 
       default:
         return cn(baseClasses, primaryButtonClasses);
@@ -263,6 +275,7 @@ type DefaultProps = {
   leadingIcon: ((props: any) => JSX.Element) | null;
   trailingIcon: ((props: any) => JSX.Element) | null;
   dataTestId: string;
+  gradientClass: string;
 };
 
 
@@ -283,7 +296,8 @@ Button.defaultProps = {
   isDisabled: false,
   leadingIcon: null,
   trailingIcon: null,
-  dataTestId: ''
+  dataTestId: '',
+  gradientClass: ''
 } as DefaultProps;
 
 export type Props = DefaultProps & RequiredProps & OptionalProps & ButtonProps & AnchorButtonProps;


### PR DESCRIPTION
## What does this PR do?
- Added a gradient variant to ui-toolkit/Button component
- user can pass class which contains `background : {gradient_config}`

<img width="679" alt="Screenshot 2025-06-12 at 11 54 18 PM" src="https://github.com/user-attachments/assets/fb12b9fb-ae11-4550-9631-750580b683c7" />

## What packages have been affected by this PR?
`ui-toolkit`

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?


## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
